### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,6 +217,6 @@ RUN freshclam
 # CLEANING
 RUN apt-get autoremove -y && apt-get clean && rm -rf /tmp/*
 
-VOLUME ["/var/www/","/var/mail/","/var/backup/","/var/lib/mysql","/var/log/"]
+VOLUME ["/var/www/","/var/mail/","/var/backup/","/usr/local/ispconfig", "/var/lib/mysql","/var/log/"]
 
 CMD ["/bin/bash", "/start.sh"]


### PR DESCRIPTION
Added "/usr/local/ispconfig" as volume to persist ispconfig data. This is necessary to avoid startup problems after rm the container.